### PR TITLE
fix: Fix filtering by transaction type [DEV-5415]

### DIFF
--- a/apps/web-cheqd/src/components/transaction_type_filter/hooks.ts
+++ b/apps/web-cheqd/src/components/transaction_type_filter/hooks.ts
@@ -186,7 +186,33 @@ export const useTransactionTypeFilter = () => {
 
   // Handle filtering transactions based on selected filters
   const handleFilterTxs = () => {
-    const str = selectedFilters.join(',');
+    // Some labels have multiple types (e.g., "cosmos.gov.v1.MsgSubmitProposal and cosmos.gov.v1beta1.MsgSubmitProposal")
+    // We need to split comma-separated types and normalize each one
+    const allTypes: string[] = [];
+    selectedFilters.forEach((filter) => {
+      // Split by comma in case the filter contains multiple types (merged by label)
+      const types = filter.split(',').map((type) => type.trim()).filter((type) => type.length > 0);
+      types.forEach((type) => {
+        // Newer transactions are stored as "/cosmos.gov.v1.MsgSubmitProposal" and older ones as "cosmos.gov.v1.MsgSubmitProposal"
+        // Handle both formats: with and without leading slash
+        const trimmedType = type.trim();
+        if (!trimmedType) return; // Skip empty types
+        
+        const baseType = trimmedType.startsWith('/') ? trimmedType.substring(1) : trimmedType;
+        const typeWithSlash = `/${baseType}`;
+        const typeWithoutSlash = baseType;
+        
+        // Add both formats to ensure we catch all transactions
+        if (typeWithSlash && !allTypes.includes(typeWithSlash)) {
+          allTypes.push(typeWithSlash);
+        }
+        // Also add version without slash to catch transactions stored in that format
+        if (typeWithoutSlash && !allTypes.includes(typeWithoutSlash)) {
+          allTypes.push(typeWithoutSlash);
+        }
+      });
+    });
+    const str = allTypes.join(',');
     const query = `{${str}}`;
     setFilter(query);
     setSelectedFilters(selectedFilters);

--- a/apps/web-cheqd/src/components/transaction_type_filter/hooks.ts
+++ b/apps/web-cheqd/src/components/transaction_type_filter/hooks.ts
@@ -187,14 +187,14 @@ export const useTransactionTypeFilter = () => {
   // Handle filtering transactions based on selected filters
   const handleFilterTxs = () => {
     // Some labels have multiple types (e.g., "cosmos.gov.v1.MsgSubmitProposal and cosmos.gov.v1beta1.MsgSubmitProposal")
-    // We need to split comma-separated types and normalize each one
+    // Split comma-separated types and normalize each one
     const allTypes: string[] = [];
     selectedFilters.forEach((filter) => {
       // Split by comma in case the filter contains multiple types (merged by label)
       const types = filter.split(',').map((type) => type.trim()).filter((type) => type.length > 0);
       types.forEach((type) => {
         // Newer transactions are stored as "/cosmos.gov.v1.MsgSubmitProposal" and older ones as "cosmos.gov.v1.MsgSubmitProposal"
-        // Handle both formats: with and without leading slash
+        // Handle both formats
         const trimmedType = type.trim();
         if (!trimmedType) return; // Skip empty types
         

--- a/packages/ui/src/screens/transactions/hooks.ts
+++ b/packages/ui/src/screens/transactions/hooks.ts
@@ -110,7 +110,7 @@ export const useTransactions = () => {
   const transactionQuery = useMessagesByTypesQuery({
     variables: {
       limit: LIMIT,
-      offset: 1,
+      offset: 0,
       types: msgTypes ?? '{}',
     },
     onError: () => {
@@ -137,6 +137,7 @@ export const useTransactions = () => {
         variables: {
           offset: state.items.length,
           limit: LIMIT,
+          types: msgTypes ?? '{}',
         },
       })
       .then(({ data }) => {

--- a/packages/ui/src/screens/transactions/hooks.ts
+++ b/packages/ui/src/screens/transactions/hooks.ts
@@ -18,8 +18,9 @@ import { readFilter } from '@/recoil/transactions_filter';
  * and sorts by height in case it bugs out
  */
 const uniqueAndSort = R.pipe(
-  R.uniqBy((r: Transactions) => r?.hash),
-  R.sort(R.descend((r) => r?.height))
+  // Transactions type was not defined here; derive the item type from TransactionsState
+  R.uniqBy((r: TransactionsState['items'][number]) => r?.hash),
+  R.sort(R.descend((r: TransactionsState['items'][number]) => r?.height))
 );
 
 const formatTransactions = (
@@ -66,7 +67,7 @@ export const useTransactions = () => {
 
   const handleSetState = useCallback(
     (stateChange: (prevState: TransactionsState) => TransactionsState) => {
-      setState((prevState) => {
+      setState((prevState: TransactionsState) => {
         const newState = stateChange(prevState);
         return R.equals(prevState, newState) ? prevState : newState;
       });
@@ -75,7 +76,7 @@ export const useTransactions = () => {
   );
 
   useEffect(() => {
-    handleSetState((prevState) => ({
+    handleSetState((prevState: TransactionsState) => ({
       ...prevState,
       loading: true,
       items: [],
@@ -90,12 +91,12 @@ export const useTransactions = () => {
     variables: {
       types: msgTypes ?? '{}',
     },
-    onData: (data) => {
+    onData: (data: any) => {
       const newItems = uniqueAndSort([
         ...(data?.data?.data ? formatTransactions(data.data.data) : []),
         ...state.items,
       ]);
-      handleSetState((prevState) => ({
+      handleSetState((prevState: TransactionsState) => ({
         ...prevState,
         loading: false,
         items: newItems,
@@ -110,16 +111,16 @@ export const useTransactions = () => {
   const transactionQuery = useMessagesByTypesQuery({
     variables: {
       limit: LIMIT,
-      offset: 1,
+      offset: 0,
       types: msgTypes ?? '{}',
     },
     onError: () => {
-      handleSetState((prevState) => ({ ...prevState, loading: false }));
+      handleSetState((prevState: TransactionsState) => ({ ...prevState, loading: false }));
     },
-    onCompleted: (data) => {
+    onCompleted: (data: any) => {
       const itemsLength = data.messagesByTypes.length;
       const newItems = uniqueAndSort([...state.items, ...(formatTransactions(data) ?? [])]);
-      handleSetState((prevState) => ({
+      handleSetState((prevState: TransactionsState) => ({
         ...prevState,
         loading: false,
         items: newItems,
@@ -130,19 +131,20 @@ export const useTransactions = () => {
   });
 
   const loadNextPage = async () => {
-    handleSetState((prevState) => ({ ...prevState, isNextPageLoading: true }));
+  handleSetState((prevState: TransactionsState) => ({ ...prevState, isNextPageLoading: true }));
     // refetch query
     await transactionQuery
       .fetchMore({
         variables: {
           offset: state.items.length,
           limit: LIMIT,
+          types: msgTypes ?? '{}',
         },
       })
-      .then(({ data }) => {
+      .then(({ data }: any) => {
         const itemsLength = data?.messagesByTypes.length;
         const newItems = uniqueAndSort([...state.items, ...(formatTransactions(data) ?? [])]);
-        handleSetState((prevState) => ({
+        handleSetState((prevState: TransactionsState) => ({
           ...prevState,
           items: newItems,
           isNextPageLoading: false,

--- a/packages/ui/src/screens/transactions/hooks.ts
+++ b/packages/ui/src/screens/transactions/hooks.ts
@@ -18,9 +18,8 @@ import { readFilter } from '@/recoil/transactions_filter';
  * and sorts by height in case it bugs out
  */
 const uniqueAndSort = R.pipe(
-  // Transactions type was not defined here; derive the item type from TransactionsState
-  R.uniqBy((r: TransactionsState['items'][number]) => r?.hash),
-  R.sort(R.descend((r: TransactionsState['items'][number]) => r?.height))
+  R.uniqBy((r: Transactions) => r?.hash),
+  R.sort(R.descend((r) => r?.height))
 );
 
 const formatTransactions = (
@@ -67,7 +66,7 @@ export const useTransactions = () => {
 
   const handleSetState = useCallback(
     (stateChange: (prevState: TransactionsState) => TransactionsState) => {
-      setState((prevState: TransactionsState) => {
+      setState((prevState) => {
         const newState = stateChange(prevState);
         return R.equals(prevState, newState) ? prevState : newState;
       });
@@ -76,7 +75,7 @@ export const useTransactions = () => {
   );
 
   useEffect(() => {
-    handleSetState((prevState: TransactionsState) => ({
+    handleSetState((prevState) => ({
       ...prevState,
       loading: true,
       items: [],
@@ -91,12 +90,12 @@ export const useTransactions = () => {
     variables: {
       types: msgTypes ?? '{}',
     },
-    onData: (data: any) => {
+    onData: (data) => {
       const newItems = uniqueAndSort([
         ...(data?.data?.data ? formatTransactions(data.data.data) : []),
         ...state.items,
       ]);
-      handleSetState((prevState: TransactionsState) => ({
+      handleSetState((prevState) => ({
         ...prevState,
         loading: false,
         items: newItems,
@@ -111,16 +110,16 @@ export const useTransactions = () => {
   const transactionQuery = useMessagesByTypesQuery({
     variables: {
       limit: LIMIT,
-      offset: 0,
+      offset: 1,
       types: msgTypes ?? '{}',
     },
     onError: () => {
-      handleSetState((prevState: TransactionsState) => ({ ...prevState, loading: false }));
+      handleSetState((prevState) => ({ ...prevState, loading: false }));
     },
-    onCompleted: (data: any) => {
+    onCompleted: (data) => {
       const itemsLength = data.messagesByTypes.length;
       const newItems = uniqueAndSort([...state.items, ...(formatTransactions(data) ?? [])]);
-      handleSetState((prevState: TransactionsState) => ({
+      handleSetState((prevState) => ({
         ...prevState,
         loading: false,
         items: newItems,
@@ -131,20 +130,19 @@ export const useTransactions = () => {
   });
 
   const loadNextPage = async () => {
-  handleSetState((prevState: TransactionsState) => ({ ...prevState, isNextPageLoading: true }));
+    handleSetState((prevState) => ({ ...prevState, isNextPageLoading: true }));
     // refetch query
     await transactionQuery
       .fetchMore({
         variables: {
           offset: state.items.length,
           limit: LIMIT,
-          types: msgTypes ?? '{}',
         },
       })
-      .then(({ data }: any) => {
+      .then(({ data }) => {
         const itemsLength = data?.messagesByTypes.length;
         const newItems = uniqueAndSort([...state.items, ...(formatTransactions(data) ?? [])]);
-        handleSetState((prevState: TransactionsState) => ({
+        handleSetState((prevState) => ({
           ...prevState,
           items: newItems,
           isNextPageLoading: false,


### PR DESCRIPTION
After upgrading to v4, message type of a few transactions have changed from `cosmos.<module>.v1beta1.<message-type>`  to `cosmos.<module>.v1.<message-type>`.

For ex:-

Pre v4 submit proposal tx: https://testnet-explorer.cheqd.io/transactions/AE9A39432BC7233C685621B81D38AE2241038F47D001BD728BF60E862A61A962

Post v4 submit proposal tx: https://testnet-explorer.cheqd.io/transactions/72970665D55A0A0598C06127298D3A68F72B02B33A5DE5F70E062A450B83028E

Also after upgrading to v4, message types are stored in the postgres db with a leading slashing.  
Pre v4 upgrade message type in db: `cosmos.gov.v1beta1.MsgSubmitProposal`
Post v4 upgrade message type in db: `/cosmos.gov.v1.MsgSubmitProposal`

Current filter implementation removes the leading slash from the message type before querying the db so it only shows pre v4 upgrade txs when active. This PR modifies the filter logic to query old and new message types with and without leading slashes.