### PR TITLE
fix: Optimise slow load times on transactions page on testnet explorer [DEV-5485]

### DIFF
--- a/apps/web-cheqd/src/graphql/general/message_types.graphql
+++ b/apps/web-cheqd/src/graphql/general/message_types.graphql
@@ -23,7 +23,6 @@ subscription MessagesByTypesListener($types: _text = "{}", $limit: bigint = 7, $
       messages
       logs
       block {
-        height
         timestamp
       }
     }
@@ -39,7 +38,6 @@ query MessagesByTypes($types: _text = "{}", $limit: bigint = 7, $offset: bigint 
       messages
       logs
       block {
-        height
         timestamp
       }
     }

--- a/packages/ui/src/screens/transactions/hooks.ts
+++ b/packages/ui/src/screens/transactions/hooks.ts
@@ -28,8 +28,9 @@ const formatTransactions = (
   if (!data?.messagesByTypes) return [];
 
   let formattedData = data.messagesByTypes;
-  if (data.messagesByTypes.length === 51) {
-    formattedData = data.messagesByTypes.slice(0, 51);
+  // This check is for the subscription which may return more items
+  if (data.messagesByTypes.length > 50) {
+    formattedData = data.messagesByTypes.slice(0, 50);
   }
 
   return formattedData.map((x) => {
@@ -106,7 +107,7 @@ export const useTransactions = () => {
   // ================================
   // tx query
   // ================================
-  const LIMIT = 51;
+  const LIMIT = 20;
   const transactionQuery = useMessagesByTypesQuery({
     variables: {
       limit: LIMIT,
@@ -123,7 +124,7 @@ export const useTransactions = () => {
         ...prevState,
         loading: false,
         items: newItems,
-        hasNextPage: itemsLength === 51,
+        hasNextPage: itemsLength === LIMIT,
         isNextPageLoading: false,
       }));
     },
@@ -147,7 +148,7 @@ export const useTransactions = () => {
           ...prevState,
           items: newItems,
           isNextPageLoading: false,
-          hasNextPage: itemsLength === 51,
+          hasNextPage: itemsLength === LIMIT,
         }));
       });
   };

--- a/packages/ui/src/screens/transactions/index.test.tsx
+++ b/packages/ui/src/screens/transactions/index.test.tsx
@@ -105,7 +105,7 @@ describe('screen: Transactions', () => {
                 result: mockTransactionsListenerDocument,
               },
               {
-                request: { query: TransactionsDocument, variables: { limit: 51, offset: 1 } },
+                request: { query: TransactionsDocument, variables: { limit: 20, offset: 0 } },
                 result: mockTransactionsDocument,
               },
             ]}


### PR DESCRIPTION
The transactions page takes around 12-13 seconds to load on mainnet and testnet explorers because the frontend queries the previous 51 transactions by default. All 51 transactions are queried and processed first then the transactions page is rendered which is causing issues with load times. 

This PR fixes the issue by modifying the default tx count to 20 instead of 51 and also removes an unused variable from the graphql query to lighten the query payload leading to a reduction of 5-6 seconds for loading the transactions page.  